### PR TITLE
Here is the French translation

### DIFF
--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionDescription": {
-    "message": "Search selected text on search engines of your choice via the context menu.",
+    "message": "Recherche le texte sélectionné avec les moteurs de recherches de votre choix via le menu contextuel.",
     "description": "Description of the add-on."
   },
 
@@ -12,22 +12,22 @@
 
 
   "optionsTabPlacementTitle": {
-    "message": "Open search results tab",
+    "message": "Ouvrir les résulats de recherche",
     "description": "Options title for tab placement select element."
   },
 
   "optionsTabPlacementNextToCurrent": {
-    "message": "Next to the current one",
+    "message": "À la suite de l'onglet courant",
     "description": "Select option label for tab placement: Next to the current one."
   },
 
   "optionsTabPlacementEndOfTabstrip": {
-    "message": "At the end of the tabstrip",
+    "message": "À la fin des onglets ouverts",
     "description": "Select option label for tab placement: At the end of tab strip."
   },
 
   "optionsMakeNewTabActive": {
-    "message": "Switch to the tab immediately",
+    "message": "Se rendre sur l'onglet immédiatement",
     "description": "Checkbox label: Switch to the tab immediately."
   }
 }


### PR DESCRIPTION
Alternate (better) translation for line 9 (root menu label) : 
"Rechercher <selected text> avec",
(it means "Search <selected text> with",)

I'm not sure: should I translate the description as well ?


Also, not requested, but here is the translation of the description on AMO and in the extension itself:

Recherchez le texte sélectionné sur les moteurs de recherche de votre choix via le menu contextuel.
Cliquez avec le bouton droit sur un mot ou un groupe de mots sélectionnés et effectuez une recherche via le menu contextuel.

Comment utiliser

     1.Créez un dossier dans vos Marques-pages appelé "Searches".
     2.Ajoutez des mots-clés de recherche à ce dossier: faites un clic droit sur n'importe quel champ de recherche et cliquez sur "Ajouter un mot-clé pour cette recherche ...", entrez un mot-clé et cliquez sur "Enregistrer". En savoir plus.
     3.Sélectionnez n'importe quel texte sur une page Web et faites un clic droit.
     4.Sélectionnez le moteur de recherche préféré sous "Rechercher...".
     5.Voilà.


Remerciements
Cette extension est inspirée de SmartSearch par Chris Povirk.

Problèmes connus
En raison des limites actuelles de l'API WebExtension ...

     ... seules les recherches avec la méthode GET sont supportées.
     ... seul le texte sélectionné peut être recherché (pas le texte lors d'un survol ou autres).


Si vous rencontrez des problèmes, veuillez envoyer un message sur le site de support.