### PR TITLE
Chinese Traditional translation

### DIFF
--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -17,7 +17,7 @@
 
 
   "optionsTabPlacementTitle": {
-    "message": "搜尋結果的分頁開啟於",
+    "message": "將搜尋結果分頁開啟於",
     "description": "Options title for tab placement select element."
   },
 
@@ -32,7 +32,7 @@
   },
 
   "optionsMakeNewTabActive": {
-    "message": "自動切換至結果分頁",
+    "message": "自動切換至搜尋結果分頁",
     "description": "Checkbox label: Switch to the tab immediately."
   }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1,0 +1,38 @@
+{
+  "extensionDescription": {
+    "message": "從快顯功能表挑選您想用的搜尋引擎來搜尋選取的文字。",
+    "description": "Description of the add-on."
+  },
+
+
+  "rootMenuLabel": {
+    "message": "搜尋",
+    "description": "The root menu label."
+  },
+
+  "helpMenuLabel": {
+    "message": "Context Search: 開始使用",
+    "description": "A help link if extension is not set up properly."
+  },
+
+
+  "optionsTabPlacementTitle": {
+    "message": "搜尋結果的分頁開啟於",
+    "description": "Options title for tab placement select element."
+  },
+
+  "optionsTabPlacementNextToCurrent": {
+    "message": "目前分頁的右方",
+    "description": "Select option label for tab placement: Next to the current one."
+  },
+
+  "optionsTabPlacementEndOfTabstrip": {
+    "message": "分頁列的最尾端",
+    "description": "Select option label for tab placement: At the end of tab strip."
+  },
+
+  "optionsMakeNewTabActive": {
+    "message": "自動切換至結果分頁",
+    "description": "Checkbox label: Switch to the tab immediately."
+  }
+}


### PR DESCRIPTION
I also translated the extension description on AMO:

**Summary**
從快顯功能表挑選您想用的搜尋引擎來搜尋選取的文字。靈感來自於套件「SmartSearch」，但使用 WebExtension 以利未來維護。

**About this extension**
對選取的字句點下右鍵，然後從快顯功能表進行一個搜尋的動作。

如何使用
1. 在書籤裡新增一個名稱為「Searches」的資料夾。
2. 加入搜尋引擎：在網頁中的搜尋欄位上點右鍵，選擇「設為用關鍵字搜尋…」，輸入關鍵字後按下儲存（資料夾請選擇先前新增的 Searches）。
3. 選取網頁中的文字後按下右鍵。
4. 在「搜尋: …」底下的子選單內選擇想用的搜尋引擎。
5. 就醬。

有問題嗎？
請參考[常見問題說明](https://github.com/NumeriusNegidius/Context-Search/wiki)（英）。如果您發現有 bug，請利用 [Issue Tracker](https://github.com/NumeriusNegidius/Context-Search/issues) 回報。

已知問題
由於目前 WebExtension API 的限制……
- …只支援使用 GET method 的輸入表單。
- …只能搜尋選取反白的文字（游標停留的文字或超連結文本不算數）

致謝
本擴充套件的靈感來自 Chris Povirk 所開發的 [SmartSearch](https://addons.mozilla.org/firefox/addon/smartsearch/)。